### PR TITLE
Update content: years, stats, images, shop text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ export default function App() {
                   Jaz <span className="text-amber-500 font-extrabold">BooM</span>
                 </span>
                 <span className="text-[8px] uppercase font-mono tracking-widest text-zinc-500 block">
-                  Nutritionist &amp; Personal Training
+                 Personal Training &amp; Nutritionist
                 </span>
               </div>
             </div>

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -24,7 +24,7 @@ export default function About() {
               <div className="absolute bottom-6 left-6 right-6 z-20 p-5 bg-zinc-950 border border-zinc-800 rounded-none backdrop-blur-md">
                 <div className="text-amber-500 font-display font-black uppercase tracking-wider text-base mb-1">Jaz Singh</div>
                 <p className="text-xs text-zinc-400 leading-relaxed font-mono">
-                  Nutritionist &amp; Personal Trainer (PT) with 10+ years of active fitness experience.
+                  Nutritionist &amp; Personal Trainer (PT) with 15+ years of active fitness experience.
                 </p>
               </div>
             </div>
@@ -44,7 +44,7 @@ export default function About() {
 
             <div className="space-y-6 text-zinc-300 text-base sm:text-lg leading-relaxed">
               <p className="font-extrabold text-white text-lg sm:text-xl border-l-4 border-amber-500 pl-4 py-1 leading-snug">
-                Hi, I’m Jaz — a Nutritionist and Personal Trainer (PT) with over 10 years of experience in the health &amp; fitness industry.
+                Hi, I’m Jaz — a Nutritionist and Personal Trainer (PT) with over 15 years of experience in the health &amp; fitness industry.
               </p>
 
               <p className="text-justify text-zinc-400 text-sm sm:text-base">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -138,7 +138,7 @@ export default function Hero() {
               <Trophy className="h-5 w-5" />
             </div>
             <div>
-              <div className="text-3xl font-display font-black text-white">10+ Years</div>
+              <div className="text-3xl font-display font-black text-white">15+ Years</div>
               <div className="text-[9px] text-zinc-500 font-mono uppercase tracking-widest">Industry Experience</div>
             </div>
           </div>
@@ -148,7 +148,7 @@ export default function Hero() {
               <Zap className="h-5 w-5" />
             </div>
             <div>
-              <div className="text-3xl font-display font-black text-white">15kg+ Loss</div>
+              <div className="text-3xl font-display font-black text-white">10kg+ Loss</div>
               <div className="text-[9px] text-zinc-500 font-mono uppercase tracking-widest">Average Client Results</div>
             </div>
           </div>
@@ -159,7 +159,7 @@ export default function Hero() {
             </div>
             <div>
               <div className="text-3xl font-display font-black text-white">Specialist</div>
-              <div className="text-[9px] text-zinc-500 font-mono uppercase tracking-widest">Clinical &amp; Autoimmune PT</div>
+              <div className="text-[9px] text-zinc-500 font-mono uppercase tracking-widest">Sustainable Weight Loss, Strength Training, Body Toning & Nutrition</div>
             </div>
           </div>
         </motion.div>

--- a/src/components/ProgramDetails.tsx
+++ b/src/components/ProgramDetails.tsx
@@ -23,7 +23,8 @@ export default function ProgramDetails() {
       id: "onetoonept",
       name: "1:1 Personal Training",
       tagline: "Reach your goals faster under personal professional direct care.",
-      image: "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1200&q=80",
+      //image: "https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?auto=format&fit=crop&w=1200&q=80",
+      image: "https://raw.githubusercontent.com/atmenterprise/jazzsinghpersonaltrainer/main/img/programs/1.jpg",
       duration: "60 Minute Sessions",
       whosItFor: [
         "Great for anyone who would like to follow a personalised programme to reach their health and fitness related goal faster.",
@@ -55,7 +56,8 @@ export default function ProgramDetails() {
       id: "couplept",
       name: "2:1 Personal Training",
       tagline: "Split the cost, double the motivation with partner accountability.",
-      image: "https://images.unsplash.com/photo-1518310383802-640c2de311b2?auto=format&fit=crop&w=1200&q=80",
+      //image: "https://images.unsplash.com/photo-1518310383802-640c2de311b2?auto=format&fit=crop&w=1200&q=80",
+      image: "https://raw.githubusercontent.com/atmenterprise/jazzsinghpersonaltrainer/main/img/programs/2.jpg",
       duration: "60 Minute Sessions (Shared)",
       whosItFor: [
         "If you have a common health and fitness related goal and can workout at the same time, this is a great way to share the experience and achieve your goals faster.",
@@ -87,7 +89,8 @@ export default function ProgramDetails() {
       id: "onlinept",
       name: "Online Coaching",
       tagline: "Full coaching guidance with total remote flexibility from anywhere.",
-      image: "https://images.unsplash.com/photo-1517838277536-f5f99be501cd?auto=format&fit=crop&w=1200&q=80",
+      //image: "https://images.unsplash.com/photo-1517838277536-f5f99be501cd?auto=format&fit=crop&w=1200&q=80",
+      image: "https://raw.githubusercontent.com/atmenterprise/jazzsinghpersonaltrainer/main/img/programs/3.jpg",
       duration: "Flexible Scheduling",
       whosItFor: [
         "Great for individuals who are happy following a personalised programme with more flexibility when they train.",

--- a/src/components/Shop.tsx
+++ b/src/components/Shop.tsx
@@ -37,7 +37,7 @@ export default function Shop() {
             <ul className="space-y-3 mb-8">
               <li className="flex items-center space-x-3 text-zinc-400 text-sm">
                 <CheckCircle2 className="h-4 w-4 text-amber-500 shrink-0" />
-                <span>22% Off sitewide automatically applied</span>
+                <span>Contact me to provide you with referral code</span>
               </li>
               <li className="flex items-center space-x-3 text-zinc-400 text-sm">
                 <CheckCircle2 className="h-4 w-4 text-amber-500 shrink-0" />
@@ -66,7 +66,7 @@ export default function Shop() {
             <img
               src="https://raw.githubusercontent.com/atmenterprise/jazzsinghpersonaltrainer/main/img/shop/reflex.jpg"
               alt="Reflex Nutrition Supplementation bottles"
-              className="w-full h-full object-cover hover:scale-105 transition-all duration-700"
+              className="w-full h-full object-top hover:scale-105 transition-all duration-700"
               referrerPolicy="no-referrer"
             />
             


### PR DESCRIPTION
Update UI copy and program assets: change experience mentions from 10+ to 15+ years and reorder the title to 'Personal Training & Nutritionist'. Adjust hero metrics (average client loss from 15kg+ to 10kg+) and expand the specialist services tagline. Replace Unsplash program images with project-hosted images (keep original URLs commented out). Update shop copy to ask users to contact for a referral code and tweak product image alignment (object-top) for better cropping.