### PR TITLE
Add GA analytics utils and tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# GEMINI_API_KEY: Required for Gemini AI API calls.
+# AI Studio automatically injects this at runtime from user secrets.
+# Users configure this via the Secrets panel in the AI Studio UI.
+GEMINI_API_KEY="MY_GEMINI_API_KEY"
+
+# APP_URL: The URL where this applet is hosted.
+# AI Studio automatically injects this at runtime with the Cloud Run service URL.
+# Used for self-referential links, OAuth callbacks, and API endpoints.
+APP_URL="MY_APP_URL"
+
+# GOOGLE ANALYTICS: Measurement ID (e.g. G-XXXXXXXXXX)
+VITE_GA_MEASUREMENT_ID=""

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
         run: npm ci
 
       - name: Build Application
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ vars.VITE_GA_MEASUREMENT_ID }}
         run: npm run build
 
       - name: Deploy to GitHub Pages

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import {useEffect, useState} from "react";
 import Navbar from "./components/Navbar";
 import Hero from "./components/Hero";
 import About from "./components/About";
@@ -10,9 +10,33 @@ import Booking from "./components/Booking";
 import Contact from "./components/Contact";
 import LegalModal from "./components/LegalModal";
 import { Dumbbell, ArrowUp } from "lucide-react";
+import { initGA, trackEvent, trackSectionView } from "./utils/analytics";
 
 export default function App() {
   const [legalModalType, setLegalModalType] = useState<"privacy" | "disclaimer" | "faq" | null>(null);
+
+  useEffect(() => {
+    // 1. Initialize Google Analytics
+    initGA();
+    trackSectionView("#home");
+
+    // 2. Intercept postMessages from the Calendly widget to log real bookings as conversion events
+    const handleCalendlyMessage = (e: MessageEvent) => {
+      if (e.data && e.data.event && e.data.event.indexOf("calendly.") === 0) {
+        const eventName = e.data.event;
+        if (eventName === "calendly.event_scheduled") {
+          trackEvent("calendly_booking_success", "lead_generation", "Free Strategy Session Scheduled");
+        } else if (eventName === "calendly.date_and_time_selected") {
+          trackEvent("calendly_slot_selected", "engagement", "Selected Calendly Timeslot");
+        }
+      }
+    };
+
+    window.addEventListener("message", handleCalendlyMessage);
+    return () => {
+      window.removeEventListener("message", handleCalendlyMessage);
+    };
+  }, []);
 
   const handleScrollToTop = () => {
     window.scrollTo({ top: 0, behavior: "smooth" });

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { Dumbbell, Menu, X, Calendar } from "lucide-react";
+import { trackSectionView, trackEvent } from "../utils/analytics";
 
 interface NavbarProps {
   onDisclaimerClick: () => void;
@@ -28,6 +29,11 @@ export default function Navbar({ onDisclaimerClick, onPrivacyClick, onFaqClick }
     { label: "Contact", href: "#contact" },
   ];
 
+  const handleNavClick = (label: string, href: string) => {
+    trackSectionView(href);
+    trackEvent("nav_click", "engagement", label);
+  };
+
   return (
     <nav
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
@@ -39,7 +45,7 @@ export default function Navbar({ onDisclaimerClick, onPrivacyClick, onFaqClick }
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between">
           {/* Logo */}
-          <a href="#" className="flex items-center space-x-2.5 group">
+          <a href="#" onClick={() => handleNavClick("Logo Home", "#home")} className="flex items-center space-x-2.5 group">
             <img
               src="https://raw.githubusercontent.com/atmenterprise/jazzsinghpersonaltrainer/main/img/logo/jazboom.png"
               alt="Jaz BooM Logo"
@@ -63,6 +69,7 @@ export default function Navbar({ onDisclaimerClick, onPrivacyClick, onFaqClick }
                 <a
                   key={item.label}
                   href={item.href}
+                  onClick={() => handleNavClick(item.label, item.href)}
                   className="text-zinc-400 hover:text-white transition-colors duration-200"
                 >
                   {item.label}
@@ -72,6 +79,7 @@ export default function Navbar({ onDisclaimerClick, onPrivacyClick, onFaqClick }
 
             <a
               href="#book"
+              onClick={() => handleNavClick("Free Consultation CTA", "#book")}
               className="bg-amber-500 hover:bg-white hover:text-black text-black font-display font-black uppercase text-xs tracking-widest px-6 py-3 rounded-none transition-colors duration-200 flex items-center space-x-2"
             >
               <Calendar className="h-3.5 w-3.5" />
@@ -82,7 +90,7 @@ export default function Navbar({ onDisclaimerClick, onPrivacyClick, onFaqClick }
           {/* Mobile Menu Button */}
           <div className="md:hidden flex items-center">
             <button
-              onClick={() => setIsOpen(!isOpen)}
+                onClick={() => setIsOpen(!isOpen)}
               className="inline-flex items-center justify-center p-2 rounded-lg text-slate-400 hover:text-white hover:bg-slate-900 focus:outline-none"
               aria-expanded="false"
             >
@@ -100,7 +108,10 @@ export default function Navbar({ onDisclaimerClick, onPrivacyClick, onFaqClick }
               <a
                 key={item.label}
                 href={item.href}
-                onClick={() => setIsOpen(false)}
+                onClick={() => {
+                  setIsOpen(false);
+                  handleNavClick(item.label, item.href);
+                }}
                 className="block px-3 py-3 text-sm font-bold uppercase tracking-widest text-zinc-400 hover:text-white hover:bg-zinc-900/40"
               >
                 {item.label}
@@ -109,7 +120,10 @@ export default function Navbar({ onDisclaimerClick, onPrivacyClick, onFaqClick }
             <div className="pt-4 px-3">
               <a
                 href="#book"
-                onClick={() => setIsOpen(false)}
+                onClick={() => {
+                  setIsOpen(false);
+                  handleNavClick("Free Consultation Mobile CTA", "#book");
+                }}
                 className="w-full bg-amber-500 hover:bg-white hover:text-black text-black font-display font-black uppercase text-xs tracking-widest py-4 px-4 rounded-none transition-all duration-200 flex items-center justify-center space-x-2"
               >
                 <Calendar className="h-4 w-4" />
@@ -117,9 +131,9 @@ export default function Navbar({ onDisclaimerClick, onPrivacyClick, onFaqClick }
               </a>
             </div>
             <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 pt-6 text-[10px] font-mono tracking-widest uppercase text-zinc-500">
-              <button onClick={() => { setIsOpen(false); onFaqClick(); }} className="hover:text-white transition-colors cursor-pointer">FAQs</button>
-              <button onClick={() => { setIsOpen(false); onDisclaimerClick(); }} className="hover:text-white transition-colors cursor-pointer">Disclaimer</button>
-              <button onClick={() => { setIsOpen(false); onPrivacyClick(); }} className="hover:text-white transition-colors cursor-pointer">Privacy Policy</button>
+              <button onClick={() => { setIsOpen(false); onFaqClick(); trackEvent("view_faqs", "engagement", "FAQ Modal Open"); }} className="hover:text-white transition-colors cursor-pointer">FAQs</button>
+              <button onClick={() => { setIsOpen(false); onDisclaimerClick(); trackEvent("view_disclaimer", "legal", "Disclaimer Modal Open"); }} className="hover:text-white transition-colors cursor-pointer">Disclaimer</button>
+              <button onClick={() => { setIsOpen(false); onPrivacyClick(); trackEvent("view_privacy", "legal", "Privacy Modal Open"); }} className="hover:text-white transition-colors cursor-pointer">Privacy Policy</button>
             </div>
           </div>
         </div>

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,91 @@
+// src/utils/analytics.ts
+
+// Declare global types for Google Analytics window object
+declare global {
+  interface Window {
+    dataLayer: any[];
+    gtag?: (...args: any[]) => void;
+  }
+}
+
+// Load Measurement ID from Environment or default to a demo tracker to prevent crashes
+export const GA_MEASUREMENT_ID = (import.meta as any).env?.VITE_GA_MEASUREMENT_ID || "";
+
+/**
+ * Initializes Google Analytics by dynamically injecting standard scripts in the head tag.
+ */
+export const initGA = () => {
+  if (typeof window === "undefined" || !GA_MEASUREMENT_ID) {
+    console.log("[Google Analytics] Bypassed initialization (No Measurement ID defined in VITE_GA_MEASUREMENT_ID).");
+    return;
+  }
+
+  // Avoid duplicate tags
+  if (document.getElementById("google-analytics-script")) return;
+
+  try {
+    // 1. Create and inject external Google tag script
+    const script = document.createElement("script");
+    script.async = true;
+    script.id = "google-analytics-script";
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+    document.head.appendChild(script);
+
+    // 2. Setup gtag proxy call and dataLayer
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function gtag() {
+      // eslint-disable-next-line prefer-rest-params
+      window.dataLayer.push(arguments);
+    };
+
+    // 3. Setup standard config variables
+    window.gtag("js", new Date());
+    window.gtag("config", GA_MEASUREMENT_ID, {
+      page_path: window.location.pathname + window.location.search,
+      anonymize_ip: true,
+    });
+
+    console.log(`[Google Analytics] Loaded and tracking actively with ID: ${GA_MEASUREMENT_ID}`);
+  } catch (err) {
+    console.error("[Google Analytics] Setup crashed:", err);
+  }
+};
+
+/**
+ * Tracks a custom event in Google Analytics.
+ * @param action Standard or custom event action name
+ * @param category Broad grouping class (e.g. Lead, Navigate, click)
+ * @param label Human-readable identifier for details
+ * @param value Integer value if applicable
+ */
+export const trackEvent = (
+  action: string,
+  category: string,
+  label?: string,
+  value?: number
+) => {
+  if (typeof window !== "undefined" && window.gtag && GA_MEASUREMENT_ID) {
+    window.gtag("event", action, {
+      event_category: category,
+      event_label: label,
+      value: value,
+    });
+  } else {
+    console.debug(`[Analytics Event Log] action: "${action}" | category: "${category}" | label: "${label || "none"}"`);
+  }
+};
+
+/**
+ * Page view tracking for SPAs / single site section anchor clicks
+ * @param path the path or hash section navigated to (e.g., "#book", "#results")
+ */
+export const trackSectionView = (path: string) => {
+  if (typeof window !== "undefined" && window.gtag && GA_MEASUREMENT_ID) {
+    window.gtag("config", GA_MEASUREMENT_ID, {
+      page_path: window.location.pathname + path,
+      page_title: `Section: ${path.replace("#", "").toUpperCase()}`,
+    });
+  } else {
+    console.debug(`[Analytics View Log] Section: ${path}`);
+  }
+};


### PR DESCRIPTION
Introduce Google Analytics support and instrumentation across the app. Adds .env.example (GEMINI_API_KEY, APP_URL, VITE_GA_MEASUREMENT_ID), updates deploy workflow to pass VITE_GA_MEASUREMENT_ID into the build, and adds src/utils/analytics.ts with initGA, trackEvent, and trackSectionView (graceful no-ID fallback). Integrates analytics in App.tsx (initialization, section view tracking, and Calendly postMessage handling for booking events) and instruments Navbar clicks and modal opens to emit analytics events.